### PR TITLE
Fix setuptools_scm configuration for version detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ dependencies = [
 readme = "README.md"
 requires-python = ">=3.7"
 dynamic = ["version"]
+
+[tool.setuptools]
+packages = ["umep-reqs"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
## Summary
- Fixed the version detection issue that was causing the publish workflow to fail
- The package was being built with version 0.0.0, causing PyPI to reject it

## Problem
The last GitHub Actions run failed with:
```
Checking dist/umep_reqs-0.0.0-py3-none-any.whl: ERROR InvalidDistribution: Metadata is missing required fields: Name, Version.
```

This happened because:
1. The new pyproject.toml was missing setuptools_scm configuration
2. Without proper configuration, the package was built with version 0.0.0
3. PyPI rejects packages with invalid version numbers

## Solution
- Added `[tool.setuptools]` section to configure package discovery
- Added `[tool.setuptools_scm]` section to enable version detection from git tags
- The package now correctly detects version from git tags (e.g., 2.4.dev13+gab28aa5)

## Test plan
- [x] Tested build locally with `python -m build` - version is correctly detected
- [ ] GitHub Actions should now build the package with proper version
- [ ] Publishing to Test PyPI should succeed with valid metadata