### PR TITLE
chore(deps): update supy to 2026.1.28rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "UMEP requirements package"
 authors = [{ name = "UMEP dev team" }]
 dependencies = [
     "timezonefinder==6.5.9",
-    "supy==2025.7.9.dev0",
+    "supy==2026.1.28rc1",
     "numba==0.59.0",
     "jaydebeapi==1.2.3",
     "netCDF4",


### PR DESCRIPTION
## Summary

- Updates supy from 2025.7.9.dev0 to 2026.1.28rc1
- This release includes QGIS stability improvements (crash fixes, thread safety)
- Maintains `numpy<2.0` compatibility required for the OSGeo/QGIS environment

## Context

See announcement: https://community.suews.io/t/suews-v2026-1-28-qgis-stability-improvements/39

The rc1 build is specifically compiled with `numpy<2.0,>=1.22` to work within QGIS's pinned numpy 1.26.x environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)