### PR TITLE
Fix QGIS 3/4 compatibility: extras for supy 2026.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "umep-reqs"
 description = "UMEP requirements package"
 authors = [{ name = "UMEP dev team" }]
 dependencies = [
-    "supy==2026.1.28",
     "pyarrow<23",  # temporary: supy 2026.1.28 _load.py incompatible with pyarrow 23 (UMEP-dev/SUEWS#1252)
     "numba==0.59.0",
     "jaydebeapi==1.2.3",
@@ -22,10 +21,12 @@ readme = "README.md"
 requires-python = ">=3.7"
 dynamic = ["version"]
 
+[project.optional-dependencies]
+qgis3 = ["supy==2026.1.28rc1"]
+qgis4 = ["supy==2026.1.28"]
+
 [tool.setuptools]
 packages = ["umep-reqs"]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
-    
-# "supy==2025.7.23.dev0", testing without supy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "umep-reqs"
 description = "UMEP requirements package"
 authors = [{ name = "UMEP dev team" }]
 dependencies = [
-    "pyarrow<23",  # temporary: supy 2026.1.28 _load.py incompatible with pyarrow 23 (UMEP-dev/SUEWS#1252)
     "numba==0.59.0",
     "jaydebeapi==1.2.3",
     "netCDF4",
@@ -22,8 +21,8 @@ requires-python = ">=3.7"
 dynamic = ["version"]
 
 [project.optional-dependencies]
-qgis3 = ["supy==2026.1.28rc1"]
-qgis4 = ["supy==2026.1.28"]
+qgis3 = ["supy==2026.4.3rc1"]
+qgis4 = ["supy==2026.4.3"]
 
 [tool.setuptools]
 packages = ["umep-reqs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "umep-reqs"
 description = "UMEP requirements package"
 authors = [{ name = "UMEP dev team" }]
 dependencies = [
-    "supy==2026.1.28rc1",
+    "supy==2026.1.28",
+    "pyarrow<23",  # temporary: supy 2026.1.28 _load.py incompatible with pyarrow 23 (UMEP-dev/SUEWS#1252)
     "numba==0.59.0",
     "jaydebeapi==1.2.3",
     "netCDF4",


### PR DESCRIPTION
## Summary

- Move supy version pin to **optional-dependencies** (extras) for QGIS 3/4 compatibility
- `pip install umep-reqs[qgis3]` -> `supy==2026.4.3rc1` (NumPy 1.x)
- `pip install umep-reqs[qgis4]` -> `supy==2026.4.3` (NumPy 2.x)
- Drop temporary `pyarrow<23` cap — the incompatible code path was refactored in supy 2026.4.3

## Background

QGIS 3 and QGIS 4 both use Python 3.12, so PEP 508 environment markers cannot distinguish them. Instead, extras let the UMEP plugin select the right supy build based on the detected QGIS version:

- **QGIS 3** (NumPy 1.x): `supy==2026.4.3rc1`
- **QGIS 4** (NumPy 2.x): `supy==2026.4.3`

Companion PR: UMEP-dev/UMEP#831 wires up the version detection in `umep_installer.py`.

Ref: UMEP-dev/SUEWS#1274, UMEP-dev/SUEWS#1252