### PR TITLE
Require target-py>=0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "jaydebeapi==1.2.3",
     "netCDF4",
     "openpyxl",
-    "target-py",
+    "target-py>=0.2.0",
     "uwg"
 ]
 


### PR DESCRIPTION
target-py 0.2.0 (https://pypi.org/project/target-py/0.2.0/) adds the `feedback` parameter to `Target(...)` that UMEP-dev/UMEP-processing#142 relies on to route progress through QgsProcessingFeedback instead of tqdm (fixing UMEP-dev/UMEP-processing#116). Older target-py versions do not accept that parameter, so this pins the minimum version accordingly.

0.2.0 also fixes a couple of other bugs relevant to UMEP users: the fg/fw NaN bug when roof fraction is 1.0 or SVF lands exactly on a bucket boundary, and the pandas frequency-alias crash from UMEP-dev/UMEP-processing#135 (pandas removed the 'T' alias for minutes).